### PR TITLE
Then + ThenAsync Refactoring

### DIFF
--- a/src/RailwayResult.FunctionalExtensions/ResultExtensions.Then.cs
+++ b/src/RailwayResult.FunctionalExtensions/ResultExtensions.Then.cs
@@ -127,46 +127,4 @@ public static partial class ResultExtensions
 		var result = await resultTask;
 		return result.Then(mapper);
 	}
-
-	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Result<TValue> result, Func<TValue, Task<TOut>> asyncMapper)
-	{
-		if (result.IsFailure)
-			return result.Error;
-
-		return await asyncMapper(result.Value);
-	}
-
-	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Task<Result<TValue>> resultTask, Func<TValue, Task<TOut>> asyncMapper)
-	{
-		var result = await resultTask;
-		return await result.ThenAsync(asyncMapper);
-	}
-
-	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
-	{
-		if (result.IsFailure)
-			return result.Error;
-
-		return await asyncMapper(result.Value.Item1, result.Value.Item2);
-	}
-
-	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
-	{
-		var result = await resultTask;
-		return await result.ThenAsync(asyncMapper);
-	}
-
-	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
-	{
-		if (result.IsFailure)
-			return result.Error;
-
-		return await asyncMapper(result.Value.Item1, result.Value.Item2);
-	}
-
-	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
-	{
-		var self = await resultTask;
-		return await self.ThenAsync(asyncMapper);
-	}
 }

--- a/src/RailwayResult.FunctionalExtensions/ResultExtensions.Then.cs
+++ b/src/RailwayResult.FunctionalExtensions/ResultExtensions.Then.cs
@@ -44,6 +44,20 @@ public static partial class ResultExtensions
 		return result.Then(mapper);
 	}
 
+	public static Result Then<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Result> mapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return mapper(result.Value.Item1, result.Value.Item2);
+	}
+
+	public static async Task<Result> Then<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Result> mapper)
+	{
+		var result = await resultTask;
+		return result.Then(mapper);
+	}
+
 	public static Result<TOut> Then<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, TOut> mapper)
 	{
 		if (result.IsFailure)
@@ -72,6 +86,20 @@ public static partial class ResultExtensions
 		return result.Then(mapper);
 	}
 
+	public static Result Then<TFirst, TSecond, TThird>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Result> mapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return mapper(result.Value.Item1, result.Value.Item2, result.Value.Item3);
+	}
+
+	public static async Task<Result> Then<TFirst, TSecond, TThird>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Result> mapper)
+	{
+		var result = await resultTask;
+		return result.Then(mapper);
+	}
+
 	public static Result<TOut> Then<TFirst, TSecond, TThird, TOut>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, TOut> mapper)
 	{
 		if (result.IsFailure)
@@ -86,7 +114,7 @@ public static partial class ResultExtensions
 		return result.Then(mapper);
 	}
 
-	public static Result Then<TFirst, TSecond, TThird>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Result> mapper)
+	public static Result<TOut> Then<TFirst, TSecond, TThird, TOut>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Result<TOut>> mapper)
 	{
 		if (result.IsFailure)
 			return result.Error;
@@ -94,7 +122,7 @@ public static partial class ResultExtensions
 		return mapper(result.Value.Item1, result.Value.Item2, result.Value.Item3);
 	}
 
-	public static async Task<Result> Then<TFirst, TSecond, TThird>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Result> mapper)
+	public static async Task<Result<TOut>> Then<TFirst, TSecond, TThird, TOut>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Result<TOut>> mapper)
 	{
 		var result = await resultTask;
 		return result.Then(mapper);

--- a/src/RailwayResult.FunctionalExtensions/ResultExtensions.ThenAsync.cs
+++ b/src/RailwayResult.FunctionalExtensions/ResultExtensions.ThenAsync.cs
@@ -1,0 +1,130 @@
+﻿namespace RailwayResult;
+
+public static partial class ResultExtensions
+{
+	public static async Task<Result> ThenAsync<TValue>(this Result<TValue> result, Func<TValue, Task<Result>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value);
+	}
+
+	public static async Task<Result> ThenAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task<Result>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Result<TValue> result, Func<TValue, Task<TOut>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Task<Result<TValue>> resultTask, Func<TValue, Task<TOut>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Result<TValue> result, Func<TValue, Task<Result<TOut>>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TValue, TOut>(this Task<Result<TValue>> resultTask, Func<TValue, Task<Result<TOut>>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result> ThenAsync<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<Result>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2);
+	}
+
+	public static async Task<Result> ThenAsync<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task<Result>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> selfTask, Func<TFirst, TSecond, Task<TOut>> asyncMapper)
+	{
+		var self = await selfTask;
+		return await self.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TOut>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task<Result<TOut>>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result> ThenAsync<TFirst, TSecond, TThird>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Task<Result>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2, result.Value.Item3);
+	}
+
+	public static async Task<Result> ThenAsync<TFirst, TSecond, TThird>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Task<Result>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TThird, TOut>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Task<TOut>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2, result.Value.Item3);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TThird, TOut>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Task<TOut>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TThird, TOut>(this Result<(TFirst, TSecond, TThird)> result, Func<TFirst, TSecond, TThird, Task<Result<TOut>>> asyncMapper)
+	{
+		if (result.IsFailure)
+			return result.Error;
+
+		return await asyncMapper(result.Value.Item1, result.Value.Item2, result.Value.Item3);
+	}
+
+	public static async Task<Result<TOut>> ThenAsync<TFirst, TSecond, TThird, TOut>(this Task<Result<(TFirst, TSecond, TThird)>> resultTask, Func<TFirst, TSecond, TThird, Task<Result<TOut>>> asyncMapper)
+	{
+		var result = await resultTask;
+		return await result.ThenAsync(asyncMapper);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/AndTests/TheoryData_R1_AndAsync.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/AndTests/TheoryData_R1_AndAsync.cs
@@ -4,6 +4,8 @@ public sealed class TheoryData_R1_AndAsync : TheoryData<Func<R1, Task<R2>>, R1, 
 {
 	public TheoryData_R1_AndAsync()
 	{
+		// --- R1 ---
+
 		Add(
 			result => result.AndAsync(_ => Task.FromResult(O.B)),
 			O.A,
@@ -20,14 +22,14 @@ public sealed class TheoryData_R1_AndAsync : TheoryData<Func<R1, Task<R2>>, R1, 
 		// --- TaskOfR1 ---
 
 		Add(
-			result => Task.FromResult(result).AndAsync(_ => Task.FromResult(O.B)),
+			result => result.ToResultTask().AndAsync(_ => Task.FromResult(O.B)),
 			O.A,
 			(O.A, O.B)
 		);
 
 		//and should return input failure result
 		Add(
-			result => Task.FromResult(result).AndAsync(_ => Task.FromResult(O.B)),
+			result => result.ToResultTask().AndAsync(_ => Task.FromResult(O.B)),
 			Errors.ErrorA,
 			Errors.ErrorA
 		);

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ComparerExtension.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ComparerExtension.cs
@@ -2,6 +2,19 @@
 
 public static class ComparerExtension
 {
+	public static void ShouldBe(this Result self, Result expected)
+	{
+		if (self.IsSuccess)
+		{
+			expected.IsSuccess.Should().BeTrue();
+		}
+		else
+		{
+			expected.IsSuccess.Should().BeFalse();
+			self.Error.Should().BeEquivalentTo(expected.Error);
+		}
+	}
+
 	public static void ShouldBe<T>(this Result<T> self, Result<T> expected)
 	{
 		if (self.IsSuccess)

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ErrorExtensions.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ErrorExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests;
+
+public static class ErrorExtensions
+{
+	public static Result ToResult<TError>(this TError error) where TError : Error => error;
+
+	public static Result<T> ToResult<T, TError>(this TError error) where TError : Error => error;
+
+	public static Task<Result> ToResultTask<TError>(this TError error) where TError : Error
+	{
+		Result r = error;
+		return Task.FromResult(r);
+	}
+
+	public static Task<Result<T>> ToResultTask<T, TError>(this TError error) where TError : Error
+	{
+		Result<T> r = error;
+		return Task.FromResult(r);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/GlobalUsings.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/GlobalUsings.cs
@@ -3,6 +3,7 @@
 global using Xunit;
 
 global using O = RailwayResult.FunctionalExtensions.Tests.Obj;
+global using RC = RailwayResult.Result<string?>;
 global using R1 = RailwayResult.Result<RailwayResult.FunctionalExtensions.Tests.Obj>;
 global using R1N = RailwayResult.Result<RailwayResult.FunctionalExtensions.Tests.Obj?>;
 global using R2 = RailwayResult.Result<(RailwayResult.FunctionalExtensions.Tests.Obj, RailwayResult.FunctionalExtensions.Tests.Obj)>;

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ResultExtensions.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ResultExtensions.cs
@@ -1,6 +1,6 @@
 ﻿namespace RailwayResult.FunctionalExtensions.Tests;
 
-public static class ComparerExtension
+public static class ResultExtensions
 {
 	public static void ShouldBe(this Result self, Result expected)
 	{
@@ -28,4 +28,8 @@ public static class ComparerExtension
 			self.Error.Should().BeEquivalentTo(expected.Error);
 		}
 	}
+
+	public static Task<Result> ToResultTask(this Result result) => Task.FromResult(result);
+
+	public static Task<Result<T>> ToResultTask<T>(this Result<T> result) => Task.FromResult(result);
 }

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/ThenAsyncTests.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/ThenAsyncTests.cs
@@ -1,0 +1,54 @@
+﻿using RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class ThenAsyncTests
+{
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_ThenAsync_TaskOfR))]
+	public async Task R1_ThenAsync_TaskOfR(Func<R1, Task<Result>> thenAsync, R1 input, Result expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_ThenAsync_TaskOfRC))]
+	public async Task R1_ThenAsync_TaskOfRC(Func<R1, Task<RC>> thenAsync, R1 input, RC expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_ThenAsync_TaskOfR))]
+	public async Task R2_ThenAsync_TaskOfR(Func<R2, Task<Result>> thenAsync, R2 input, Result expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_ThenAsync_TaskOfRC))]
+	public async Task R2_Thensync_TAskOfRC(Func<R2, Task<RC>> thenAsync, R2 input, RC expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R3_ThenAsync_TaskOfR))]
+	public async Task R3_ThenAsync_TaskOfR(Func<R3, Task<Result>> thenAsync, R3 input, Result expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R3_ThenAsync_TaskOfRC))]
+	public async Task R3_ThenAsync_TaskOfRC(Func<R3, Task<RC>> thenAsync, R3 input, RC expectedOutput)
+	{
+		var result = await thenAsync.Invoke(input);
+		result.ShouldBe(expectedOutput);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R1_ThenAsync_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R1_ThenAsync_TaskOfR.cs
@@ -1,0 +1,65 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R1_ThenAsync_TaskOfR : TheoryData<Func<R1, Task<Result>>, R1, Result>
+{
+	public TheoryData_R1_ThenAsync_TaskOfR()
+	{
+		// --- R1 ThenAsync TaskOfR ---
+
+		Add(
+			result => result.ThenAsync(_ => Result.Success.ToResultTask()),
+			O.A,
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync(_ => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync(_ => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync(_ => Errors.ErrorB.ToResultTask()),
+			O.A,
+			Errors.ErrorB
+		);
+
+		// --- TaskOfR1 ThenAsync TaskOfR ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Result.Success.ToResultTask()),
+			O.A,
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Errors.ErrorB.ToResultTask()),
+			O.A,
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R1_ThenAsync_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R1_ThenAsync_TaskOfRC.cs
@@ -1,0 +1,115 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R1_ThenAsync_TaskOfRC : TheoryData<Func<R1, Task<RC>>, R1, RC>
+{
+	public TheoryData_R1_ThenAsync_TaskOfRC()
+	{
+		// --- R1 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ThenAsync(o => Task.FromResult(o.Value)),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.ThenAsync(_ => Task.FromResult("CC"))!,
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync(o => Task.FromResult(o.Value)),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ThenAsync(o => RC.Success(o.Value).ToResultTask()),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.ThenAsync(_ => RC.Success("CC").ToResultTask()),
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync(o => RC.Success(o.Value).ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync(_ => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			O.A,
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync(_ => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		// --- TaskOfR1 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync(o => Task.FromResult(o.Value)),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Task.FromResult("CC"))!,
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(o => Task.FromResult(o.Value)),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync(o => RC.Success(o.Value).ToResultTask()),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => RC.Success("CC").ToResultTask()),
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(o => RC.Success(o.Value).ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			O.A,
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync(_ => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R2_ThenAsync_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R2_ThenAsync_TaskOfR.cs
@@ -1,0 +1,65 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R2_ThenAsync_TaskOfR : TheoryData<Func<R2, Task<Result>>, R2, Result>
+{
+	public TheoryData_R2_ThenAsync_TaskOfR()
+	{
+		// --- R2 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ThenAsync((_, _) => Result.Success.ToResultTask()),
+			(O.A, O.B),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _) => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _) => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync((_, _) => Errors.ErrorB.ToResultTask()),
+			(O.A, O.B),
+			Errors.ErrorB
+		);
+
+		// --- TaskOfR2 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Result.Success.ToResultTask()),
+			(O.A, O.B),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Errors.ErrorB.ToResultTask()),
+			(O.A, O.B),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R2_ThenAsync_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R2_ThenAsync_TaskOfRC.cs
@@ -1,0 +1,115 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R2_ThenAsync_TaskOfRC : TheoryData<Func<R2, Task<RC>>, R2, RC>
+{
+	public TheoryData_R2_ThenAsync_TaskOfRC()
+	{
+		// --- R2 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ThenAsync((a, b) => Task.FromResult(a.Value + b.Value))!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.ThenAsync((_, _) => Task.FromResult("CC"))!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _) => Task.FromResult("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ThenAsync((a, b) => RC.Success(a.Value + b.Value).ToResultTask())!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.ThenAsync((_, _) => RC.Success("CC").ToResultTask())!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _) => RC.Success("CC").ToResultTask())!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _) => Errors.ErrorC.ToResultTask<string?, BasicError>())!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync((_, _) => Errors.ErrorC.ToResultTask<string?, BasicError>())!,
+			(O.A, O.B),
+			Errors.ErrorC
+		);
+
+		// --- TaskOfR2 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync((a, b) => Task.FromResult(a.Value + b.Value))!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Task.FromResult("CC"))!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Task.FromResult("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((a, b) => RC.Success(a.Value + b.Value).ToResultTask())!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => RC.Success("CC").ToResultTask())!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => RC.Success("CC").ToResultTask())!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Errors.ErrorC.ToResultTask<string?, BasicError>())!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _) => Errors.ErrorC.ToResultTask<string?, BasicError>())!,
+			(O.A, O.B),
+			Errors.ErrorC
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R3_ThenAsync_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R3_ThenAsync_TaskOfR.cs
@@ -1,0 +1,65 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R3_ThenAsync_TaskOfR : TheoryData<Func<R3, Task<Result>>, R3, Result>
+{
+	public TheoryData_R3_ThenAsync_TaskOfR()
+	{
+		// --- R3 ThenAsync TaskOfR ---
+
+		Add(
+			result => result.ThenAsync((_, _, _) => Result.Success.ToResultTask()),
+			(O.A, O.B, O.C),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask()),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+
+		// --- TaskOfR3 ThenAsync TaskOfR ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Result.Success.ToResultTask()),
+			(O.A, O.B, O.C),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Result.Success.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask()),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R3_ThenAsync_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenAsyncTests/TheoryData_R3_ThenAsync_TaskOfRC.cs
@@ -1,0 +1,115 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenAsyncTests;
+
+public sealed class TheoryData_R3_ThenAsync_TaskOfRC : TheoryData<Func<R3, Task<RC>>, R3, RC>
+{
+	public TheoryData_R3_ThenAsync_TaskOfRC()
+	{
+		// --- R3 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ThenAsync((a, b, c) => Task.FromResult(a.Value + b.Value + c.Value))!,
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.ThenAsync((_, _, _) => Task.FromResult("CC"))!,
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Task.FromResult("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ThenAsync((a, b, c) => RC.Success(a.Value + b.Value + c.Value).ToResultTask()),
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.ThenAsync((_, _, _) => RC.Success("CC").ToResultTask()),
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => RC.Success("CC").ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		// --- TaskOfR3 ThenAsync TaskOfRC ---
+
+		Add(
+			result => result.ToResultTask().ThenAsync((a, b, c) => Task.FromResult(a.Value + b.Value + c.Value))!,
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Task.FromResult("CC"))!,
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Task.FromResult("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((a, b, c) => RC.Success(a.Value + b.Value + c.Value).ToResultTask()),
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => RC.Success("CC").ToResultTask()),
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => RC.Success("CC").ToResultTask()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.ToResultTask().ThenAsync((_, _, _) => Errors.ErrorB.ToResultTask<string?, BasicError>()),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/ThenTests.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/ThenTests.cs
@@ -1,6 +1,4 @@
-﻿global using RC = RailwayResult.Result<string?>;
-
-namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
 
 public sealed class ThenTests
 {

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/ThenTests.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/ThenTests.cs
@@ -1,0 +1,96 @@
+﻿global using RC = RailwayResult.Result<string?>;
+
+namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class ThenTests
+{
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_Then_R))]
+	public void R1_Then_R(Func<R1, Result> then, R1 input, Result expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR1_Then_TaskOfR))]
+	public async Task TaskOfR1_Then_TaskOfR(Func<Task<R1>, Task<Result>> then, R1 input, Result expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_Then_RC))]
+	public void R1_Then_RC(Func<R1, RC> then, R1 input, RC expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR1_Then_TaskOfRC))]
+	public async Task TaskOfR1_Then_TaskOfRC(Func<Task<R1>, Task<RC>> then, R1 input, RC expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_Then_R))]
+	public void R2_Then_R(Func<R2, Result> then, R2 input, Result expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR2_Then_TaskOfR))]
+	public async Task TaskOfR2_Then_TaskOfR(Func<Task<R2>, Task<Result>> then, R2 input, Result expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_Then_RC))]
+	public void R2_Then_RC(Func<R2, RC> then, R2 input, RC expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR2_Then_TaskOfRC))]
+	public async Task TaskOfR2_Then_TaskOfRC(Func<Task<R2>, Task<RC>> then, R2 input, RC expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R3_Then_R))]
+	public void R3_Then_R(Func<R3, Result> then, R3 input, Result expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR3_Then_TaskOfR))]
+	public async Task TaskOfR3_Then_TaskOfR(Func<Task<R3>, Task<Result>> then, R3 input, Result expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R3_Then_RC))]
+	public void R3_Then_RC(Func<R3, RC> then, R3 input, RC expectedOutput)
+	{
+		then.Invoke(input).ShouldBe(expectedOutput);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR3_Then_TaskOfRC))]
+	public async Task TaskOfR3_Then_TaskOfRC(Func<Task<R3>, Task<RC>> then, R3 input, RC expectedOutput)
+	{
+		var result = await then.Invoke(Task.FromResult(input));
+		result.ShouldBe(expectedOutput);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R1_Then_R.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R1_Then_R.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R1_Then_R : TheoryData<Func<R1, Result>, R1, Result>
+{
+	public TheoryData_R1_Then_R()
+	{
+		Add(
+			result => result.Then(_ => Result.Success),
+			O.A,
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(_ => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O>(_ => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O>(_ => Errors.ErrorB),
+			O.A,
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R1_Then_RC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R1_Then_RC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R1_Then_RC : TheoryData<Func<R1, RC>, R1, RC>
+{
+	public TheoryData_R1_Then_RC()
+	{
+		Add(
+			result => result.Then(o => o.Value),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.Then(_ => "CC")!,
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(o => o.Value),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then(o => RC.Success(o.Value)),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.Then(_ => RC.Success("CC")),
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(o => RC.Success(o.Value)),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, string?>(_ => Errors.ErrorB),
+			O.A,
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, string?>(_ => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R2_Then_R.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R2_Then_R.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R2_Then_R : TheoryData<Func<R2, Result>, R2, Result>
+{
+	public TheoryData_R2_Then_R()
+	{
+		Add(
+			result => result.Then((_, _) => Result.Success),
+			(O.A, O.B),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O>((_, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O>((_, _) => Errors.ErrorB),
+			(O.A, O.B),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R2_Then_RC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R2_Then_RC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R2_Then_RC : TheoryData<Func<R2, RC>, R2, RC>
+{
+	public TheoryData_R2_Then_RC()
+	{
+		Add(
+			result => result.Then((a, b) => a.Value + b.Value)!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.Then((_, _) => "CC")!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => "CC")!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then((a, b) => RC.Success(a.Value + b.Value))!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.Then((_, _) => RC.Success("CC"))!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => RC.Success("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, string?>((_, _) => Errors.ErrorC)!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, string?>((_, _) => Errors.ErrorC)!,
+			(O.A, O.B),
+			Errors.ErrorC
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R3_Then_R.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R3_Then_R.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R3_Then_R : TheoryData<Func<R3, Result>, R3, Result>
+{
+	public TheoryData_R3_Then_R()
+	{
+		Add(
+			result => result.Then((_, _, _) => Result.Success),
+			(O.A, O.B, O.C),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, O>((_, _, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, O>((_, _, _) => Errors.ErrorB),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R3_Then_RC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_R3_Then_RC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_R3_Then_RC : TheoryData<Func<R3, RC>, R3, RC>
+{
+	public TheoryData_R3_Then_RC()
+	{
+		Add(
+			result => result.Then((a, b, c) => a.Value + b.Value + c.Value)!,
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.Then((_, _, _) => "CC")!,
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => "CC")!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then((a, b, c) => RC.Success(a.Value + b.Value + c.Value)),
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.Then((_, _, _) => RC.Success("CC")),
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => RC.Success("CC")),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, O, string?>((_, _, _) => Errors.ErrorB),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, O, string?>((_, _, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR1_Then_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR1_Then_TaskOfR.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR1_Then_TaskOfR : TheoryData<Func<Task<R1>, Task<Result>>, R1, Result>
+{
+	public TheoryData_TaskOfR1_Then_TaskOfR()
+	{
+		Add(
+			result => result.Then(_ => Result.Success),
+			O.A,
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(_ => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O>(_ => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O>(_ => Errors.ErrorB),
+			O.A,
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR1_Then_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR1_Then_TaskOfRC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR1_Then_TaskOfRC : TheoryData<Func<Task<R1>, Task<RC>>, R1, RC>
+{
+	public TheoryData_TaskOfR1_Then_TaskOfRC()
+	{
+		Add(
+			result => result.Then(o => o.Value),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.Then(_ => "CC")!,
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(o => o.Value),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then(o => RC.Success(o.Value)),
+			O.A,
+			"A"
+		);
+
+		Add(
+			result => result.Then(_ => RC.Success("CC")),
+			O.A,
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then(o => RC.Success(o.Value)),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, string?>(_ => Errors.ErrorB),
+			O.A,
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, string?>(_ => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR2_Then_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR2_Then_TaskOfR.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR2_Then_TaskOfR : TheoryData<Func<Task<R2>, Task<Result>>, R2, Result>
+{
+	public TheoryData_TaskOfR2_Then_TaskOfR()
+	{
+		Add(
+			result => result.Then((_, _) => Result.Success),
+			(O.A, O.B),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O>((_, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O>((_, _) => Errors.ErrorB),
+			(O.A, O.B),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR2_Then_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR2_Then_TaskOfRC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR2_Then_TaskOfRC : TheoryData<Func<Task<R2>, Task<RC>>, R2, RC>
+{
+	public TheoryData_TaskOfR2_Then_TaskOfRC()
+	{
+		Add(
+			result => result.Then((a, b) => a.Value + b.Value)!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.Then((_, _) => "CC")!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => "CC")!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then((a, b) => RC.Success(a.Value + b.Value))!,
+			(O.A, O.B),
+			"AB"
+		);
+
+		Add(
+			result => result.Then((_, _) => RC.Success("CC"))!,
+			(O.A, O.B),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _) => RC.Success("CC"))!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, string?>((_, _) => Errors.ErrorC)!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, string?>((_, _) => Errors.ErrorC)!,
+			(O.A, O.B),
+			Errors.ErrorC
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR3_Then_TaskOfR.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR3_Then_TaskOfR.cs
@@ -1,0 +1,34 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR3_Then_TaskOfR : TheoryData<Func<Task<R3>, Task<Result>>, R3, Result>
+{
+	public TheoryData_TaskOfR3_Then_TaskOfR()
+	{
+		Add(
+			result => result.Then((_, _, _) => Result.Success),
+			(O.A, O.B, O.C),
+			Result.Success
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => Result.Success),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, O>((_, _, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, O>((_, _, _) => Errors.ErrorB),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR3_Then_TaskOfRC.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/ThenTests/TheoryData_TaskOfR3_Then_TaskOfRC.cs
@@ -1,0 +1,59 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.ThenTests;
+
+public sealed class TheoryData_TaskOfR3_Then_TaskOfRC : TheoryData<Func<Task<R3>, Task<RC>>, R3, RC>
+{
+	public TheoryData_TaskOfR3_Then_TaskOfRC()
+	{
+		Add(
+			result => result.Then((a, b, c) => a.Value + b.Value + c.Value)!,
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.Then((_, _, _) => "CC")!,
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => "CC")!,
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		Add(
+			result => result.Then((a, b, c) => RC.Success(a.Value + b.Value + c.Value)),
+			(O.A, O.B, O.C),
+			"ABC"
+		);
+
+		Add(
+			result => result.Then((_, _, _) => RC.Success("CC")),
+			(O.A, O.B, O.C),
+			"CC"
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then((_, _, _) => RC.Success("CC")),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+
+		//then should return nested failure result
+		Add(
+			result => result.Then<O, O, O, string?>((_, _, _) => Errors.ErrorB),
+			(O.A, O.B, O.C),
+			Errors.ErrorB
+		);
+
+		//then should return input failure result
+		Add(
+			result => result.Then<O, O, O, string?>((_, _, _) => Errors.ErrorB),
+			Errors.ErrorA,
+			Errors.ErrorA
+		);
+	}
+}


### PR DESCRIPTION
* split `.ThenAsync` extension methods into separate file
* added missing `.Then` and `.ThenAsync` extension methods
* added unit tests for `.Then` and `.ThenAsync` extension methods
* added extension methods for unit testing (`.ToResultTask`)