### PR TITLE
Tap + TapAsync Refactoring

### DIFF
--- a/src/RailwayResult.FunctionalExtensions/ResultExtensions.Tap.cs
+++ b/src/RailwayResult.FunctionalExtensions/ResultExtensions.Tap.cs
@@ -2,12 +2,39 @@
 
 public static partial class ResultExtensions
 {
+	public static Result Tap(this Result result, Action func)
+	{
+		if (result.IsSuccess)
+			func();
+
+		return result;
+	}
+
+	public static async Task<Result> Tap(this Task<Result> resultTask, Action func)
+	{
+		var result = await resultTask;
+		return result.Tap(func);
+	}
+
+	public static Result Tap(this Result result, Func<Result> func)
+	{
+		if (result.IsSuccess)
+			return func();
+
+		return result;
+	}
+
+	public static async Task<Result> Tap(this Task<Result> resultTask, Func<Result> func)
+	{
+		var result = await resultTask;
+		return result.Tap(func);
+	}
+
 	public static Result<TValue> Tap<TValue>(this Result<TValue> result, Action<TValue> func)
 	{
-		if (result.IsFailure)
-			return result;
+		if (result.IsSuccess)
+			func(result.Value);
 
-		func(result.Value);
 		return result;
 	}
 
@@ -17,21 +44,29 @@ public static partial class ResultExtensions
 		return result.Tap(func);
 	}
 
-	public static async Task<Result<TValue>> Tap<TValue>(this Task<Result<Result<TValue>>> resultTask, Action<TValue> func)
-	{
-		var result = await resultTask;
-		if (result.IsFailure)
-			return result.Error;
-
-		return result.Value.Tap(func);
-	}
-
-	public static Result<(TFirst, TSecond)> Tap<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Action<TFirst, TSecond> func)
+	public static Result<TValue> Tap<TValue>(this Result<TValue> result, Func<TValue, Result> func)
 	{
 		if (result.IsFailure)
 			return result;
 
-		func(result.Value.Item1, result.Value.Item2);
+		var nestedResult = func(result.Value);
+		if (nestedResult.IsFailure)
+			return nestedResult.Error;
+
+		return result;
+	}
+
+	public static async Task<Result<TValue>> Tap<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Result> func)
+	{
+		var result = await resultTask;
+		return result.Tap(func);
+	}
+
+	public static Result<(TFirst, TSecond)> Tap<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Action<TFirst, TSecond> func)
+	{
+		if (result.IsSuccess)
+			func(result.Value.Item1, result.Value.Item2);
+
 		return result;
 	}
 
@@ -41,33 +76,31 @@ public static partial class ResultExtensions
 		return result.Tap(func);
 	}
 
-	public static async Task<Result> TapAsync(this Result result, Func<Task> asyncFunc)
-	{
-		if (result.IsFailure)
-			return result.Error;
-
-		await asyncFunc();
-		return Result.Success;
-	}
-
-	public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task> asyncFunc)
-	{
-		var result = await resultTask;
-		return await result.TapAsync(asyncFunc);
-	}
-
-	public static async Task<Result<TValue>> TapAsync<TValue>(this Result<TValue> result, Func<TValue, Task> asyncFunc)
+	public static Result<(TFirst, TSecond)> Tap<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Result> func)
 	{
 		if (result.IsFailure)
 			return result;
 
-		await asyncFunc(result.Value);
+		var nestedResult = func(result.Value.Item1, result.Value.Item2);
+		if (nestedResult.IsFailure)
+			return nestedResult.Error;
+
 		return result;
 	}
 
-	public static async Task<Result<TValue>> TapAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task> asyncFunc)
+	public static async Task<Result<(TFirst, TSecond)>> Tap<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Result> func)
 	{
 		var result = await resultTask;
-		return await result.TapAsync(asyncFunc);
+		return result.Tap(func);
+	}
+
+	[Obsolete("This methods seems useless, as Then methods should always unwrap returning result object.")]
+	public static async Task<Result<TValue>> Tap<TValue>(this Task<Result<Result<TValue>>> resultTask, Action<TValue> func)
+	{
+		var result = await resultTask;
+		if (result.IsFailure)
+			return result.Error;
+
+		return result.Value.Tap(func);
 	}
 }

--- a/src/RailwayResult.FunctionalExtensions/ResultExtensions.TapAsync.cs
+++ b/src/RailwayResult.FunctionalExtensions/ResultExtensions.TapAsync.cs
@@ -1,0 +1,96 @@
+﻿namespace RailwayResult;
+
+public static partial class ResultExtensions
+{
+	public static async Task<Result> TapAsync(this Result result, Func<Task> asyncFunc)
+	{
+		if (result.IsSuccess)
+			await asyncFunc();
+
+		return result;
+	}
+
+	public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result> TapAsync(this Result result, Func<Task<Result>> asyncFunc)
+	{
+		if (result.IsSuccess)
+			return await asyncFunc();
+
+		return result;
+	}
+
+	public static async Task<Result> TapAsync(this Task<Result> resultTask, Func<Task<Result>> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result<TValue>> TapAsync<TValue>(this Result<TValue> result, Func<TValue, Task> asyncFunc)
+	{
+		if (result.IsSuccess)
+			await asyncFunc(result.Value);
+
+		return result;
+	}
+
+	public static async Task<Result<TValue>> TapAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result<TValue>> TapAsync<TValue>(this Result<TValue> result, Func<TValue, Task<Result>> asyncFunc)
+	{
+		if (result.IsFailure)
+			return result;
+
+		var nestedResult = await asyncFunc(result.Value);
+		if (nestedResult.IsFailure)
+			return nestedResult.Error;
+
+		return result;
+	}
+
+	public static async Task<Result<TValue>> TapAsync<TValue>(this Task<Result<TValue>> resultTask, Func<TValue, Task<Result>> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> TapAsync<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task> asyncFunc)
+	{
+		if (result.IsSuccess)
+			await asyncFunc(result.Value.Item1, result.Value.Item2);
+
+		return result;
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> TapAsync<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> TapAsync<TFirst, TSecond>(this Result<(TFirst, TSecond)> result, Func<TFirst, TSecond, Task<Result>> asyncFunc)
+	{
+		if (result.IsFailure)
+			return result;
+
+		var nestedResult = await asyncFunc(result.Value.Item1, result.Value.Item2);
+		if (nestedResult.IsFailure)
+			return nestedResult.Error;
+
+		return result;
+	}
+
+	public static async Task<Result<(TFirst, TSecond)>> TapAsync<TFirst, TSecond>(this Task<Result<(TFirst, TSecond)>> resultTask, Func<TFirst, TSecond, Task<Result>> asyncFunc)
+	{
+		var result = await resultTask;
+		return await result.TapAsync(asyncFunc);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/Callback.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/Callback.cs
@@ -1,0 +1,27 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests;
+
+public sealed class Callback
+{
+	public bool WasCalled { get; private set; } = false;
+
+	public void Invoke() => WasCalled = true;
+
+	public Result ResultInvoke(BasicError? error = null)
+	{
+		WasCalled = true;
+		return error is null ? Result.Success : error;
+	}
+
+	public Task InvokeAsync()
+	{
+		WasCalled = true;
+		return Task.CompletedTask;
+	}
+
+	public Task<Result> ResultInvokeAsync(BasicError? error = null)
+	{
+		WasCalled = true;
+		return Task.FromResult(error is null ? Result.Success : error);
+	}
+
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TapAsyncTests.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TapAsyncTests.cs
@@ -1,0 +1,35 @@
+﻿using RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+namespace RailwayResult.FunctionalExtensions.Tests.TapAsyncTests;
+
+public sealed class TapAsyncTests
+{
+	private Callback Callback { get; } = new();
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R_TapAsync))]
+	public async Task R_TapAsync(Func<Result, Callback, Task<Result>> tapAsync, Result input, Result expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tapAsync.Invoke(input, Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_TapAsync))]
+	public async Task R1_TapAsync(Func<R1, Callback, Task<R1>> tapAsync, R1 input, R1 expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tapAsync.Invoke(input, Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_TapAsync))]
+	public async Task R2_TapAsync(Func<R2, Callback, Task<R2>> tapAsync, R2 input, R2 expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tapAsync.Invoke(input, Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R1_TapAsync.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R1_TapAsync.cs
@@ -1,0 +1,107 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapAsyncTests;
+
+public sealed class TheoryData_R1_TapAsync : TheoryData<Func<R1, Callback, Task<R1>>, R1, R1, bool>
+{
+	public TheoryData_R1_TapAsync()
+	{
+		// --- R1 ThenAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.InvokeAsync()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.InvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.ResultInvokeAsync()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.ResultInvokeAsync(Errors.ErrorD)),
+			O.A,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(_ => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		// --- TaskOfR1 ThenAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.InvokeAsync()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.InvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.ResultInvokeAsync()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.ResultInvokeAsync(Errors.ErrorD)),
+			O.A,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(_ => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R2_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R2_Tap.cs
@@ -1,0 +1,107 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapAsyncTests;
+
+public sealed class TheoryData_R2_TapAsync : TheoryData<Func<R2, Callback, Task<R2>>, R2, R2, bool>
+{
+	public TheoryData_R2_TapAsync()
+	{
+		// --- R2 TapAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.InvokeAsync()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.InvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.ResultInvokeAsync()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.ResultInvokeAsync(Errors.ErrorD)),
+			(O.A, O.B),
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync((_, _) => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		// --- TaskOfR2 TapAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.InvokeAsync()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.InvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.ResultInvokeAsync()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.ResultInvokeAsync(Errors.ErrorD)),
+			(O.A, O.B),
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync((_, _) => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R_TapAsync.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapAsyncTests/TheoryData_R_TapAsync.cs
@@ -1,0 +1,107 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapAsyncTests;
+
+public sealed class TheoryData_R_TapAsync : TheoryData<Func<Result, Callback, Task<Result>>, Result, Result, bool>
+{
+	public TheoryData_R_TapAsync()
+	{
+		// --- R TapAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync(callback.InvokeAsync),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(callback.InvokeAsync),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.TapAsync(() => callback.ResultInvokeAsync()),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(() => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.TapAsync(() => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Result.Success,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.TapAsync(() => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		// --- TaskOfR TapAsync ---
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(callback.InvokeAsync),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(callback.InvokeAsync),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(() => callback.ResultInvokeAsync()),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(() => callback.ResultInvokeAsync()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(() => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Result.Success,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.ToResultTask().TapAsync(() => callback.ResultInvokeAsync(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TapTests.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TapTests.cs
@@ -1,0 +1,57 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TapTests
+{
+	private Callback Callback { get; } = new();
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R_Tap))]
+	public void R_Tap(Func<Result, Callback, Result> tap, Result input, Result expectedOutput, bool wasCallbackInvoked)
+	{
+		tap.Invoke(input, Callback).ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR_Tap))]
+	public async Task TaskOfR_Tap(Func<Task<Result>, Callback, Task<Result>> tap, Result input, Result expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tap.Invoke(input.ToResultTask(), Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R1_Tap))]
+	public void R1_Tap(Func<R1, Callback, R1> tap, R1 input, R1 expectedOutput, bool wasCallbackInvoked)
+	{
+		tap.Invoke(input, Callback).ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR1_Tap))]
+	public async Task TaskOfR1_Tap(Func<Task<R1>, Callback, Task<R1>> tap, R1 input, R1 expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tap.Invoke(input.ToResultTask(), Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_R2_Tap))]
+	public void R2_Tap(Func<R2, Callback, R2> tap, R2 input, R2 expectedOutput, bool wasCallbackInvoked)
+	{
+		tap.Invoke(input, Callback).ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+
+	[Theory]
+	[ClassData(typeof(TheoryData_TaskOfR2_Tap))]
+	public async Task TaskOfR2_Tap(Func<Task<R2>, Callback, Task<R2>> tap, R2 input, R2 expectedOutput, bool wasCallbackInvoked)
+	{
+		var result = await tap.Invoke(input.ToResultTask(), Callback);
+		result.ShouldBe(expectedOutput);
+		Callback.WasCalled.Should().Be(wasCallbackInvoked);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R1_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R1_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_R1_Tap : TheoryData<Func<R1, Callback, R1>, R1, R1, bool>
+{
+	public TheoryData_R1_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.Invoke()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.Invoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke(Errors.ErrorD)),
+			O.A,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R2_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R2_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_R2_Tap : TheoryData<Func<R2, Callback, R2>, R2, R2, bool>
+{
+	public TheoryData_R2_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.Invoke()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.Invoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke(Errors.ErrorD)),
+			(O.A, O.B),
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_R_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_R_Tap : TheoryData<Func<Result, Callback, Result>, Result, Result, bool>
+{
+	public TheoryData_R_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(callback.Invoke),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(callback.Invoke),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke()),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke(Errors.ErrorD)),
+			Result.Success,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR1_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR1_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_TaskOfR1_Tap : TheoryData<Func<Task<R1>, Callback, Task<R1>>, R1, R1, bool>
+{
+	public TheoryData_TaskOfR1_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.Invoke()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.Invoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke()),
+			O.A,
+			O.A,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke(Errors.ErrorD)),
+			O.A,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR2_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR2_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_TaskOfR2_Tap : TheoryData<Func<Task<R2>, Callback, Task<R2>>, R2, R2, bool>
+{
+	public TheoryData_TaskOfR2_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.Invoke()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.Invoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke()),
+			(O.A, O.B),
+			(O.A, O.B),
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap((_, _) => callback.ResultInvoke(Errors.ErrorD)),
+			(O.A, O.B),
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(_ => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}

--- a/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR_Tap.cs
+++ b/tests/RailwayResult.FunctionalExtensions.Tests/TapTests/TheoryData_TaskOfR_Tap.cs
@@ -1,0 +1,55 @@
+﻿namespace RailwayResult.FunctionalExtensions.Tests.TapTests;
+
+public sealed class TheoryData_TaskOfR_Tap : TheoryData<Func<Task<Result>, Callback, Task<Result>>, Result, Result, bool>
+{
+	public TheoryData_TaskOfR_Tap()
+	{
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(callback.Invoke),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(callback.Invoke),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result stays on success railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke()),
+			Result.Success,
+			Result.Success,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke()),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+
+		//callback should be invoked and result should be on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke(Errors.ErrorD)),
+			Result.Success,
+			Errors.ErrorD,
+			true
+		);
+
+		//callback should not be invoked and result stays on failure railway
+		Add(
+			(result, callback) => result.Tap(() => callback.ResultInvoke(Errors.ErrorD)),
+			Errors.ErrorA,
+			Errors.ErrorA,
+			false
+		);
+	}
+}


### PR DESCRIPTION
* split `.TapAsync` extension methods into separate file
* added missing `.Tap` and `.TapAsync` extension methods
* added unit tests for  `.Tap` and `.TapAsync` extension methods
* marked one  `.Tap` extension method as obsolete

```csharp
[Obsolete("This methods seems useless, as Then methods should always unwrap returning result object.")]
Task<Result<TValue>> Tap<TValue>(this Task<Result<Result<TValue>>> resultTask, Action<TValue> func)
```